### PR TITLE
Add windows and macOS testing via azure-pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,49 @@
+# Python package
+# Create and test a Python package on multiple Python versions.
+# Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
+# https://docs.microsoft.com/azure/devops/pipelines/languages/python
+
+trigger:
+- master
+- stable
+
+strategy:
+  matrix:
+    Python35_Windows:
+      python.version: '3.5'
+      TOXENV: py35
+      imageName: "vs2017-win2016"
+    Python36_Windows:
+      python.version: '3.6'
+      TOXENV: py36
+      imageName: "vs2017-win2016"
+    Python37_Windows:
+      python.version: '3.7'
+      TOXENV: py37
+      imageName: "vs2017-win2016"
+    Python35_macOS:
+      python.version: '3.5'
+      TOXENV: py35
+      imageName: "macOS-10.13"
+    Python36_macOS:
+      python.version: '3.6'
+      TOXENV: py36
+      imageName: "macOS-10.13"
+    Python37_macOS:
+      python.version: '3.7'
+      TOXENV: py37
+      imageName: "macOS-10.13"
+pool:
+  vmImage: $(imageName)
+steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+  - bash: |
+      set -e
+      python -m pip install --upgrade pip
+      pip install tox
+    displayName: 'Install job dependencies'
+  - script: tox -e%TOXENV%
+    displayName: 'Install package/test dependencies and run tests'


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

This commit adds macOS and windows testing using azure pipelines. The
travis support for both macOS and Windows aren't as good as on
azure-pipelines. So this commit adds the testing there to ensure we have
testing coverage on windows and macOS.

### Details and comments

