### PR TITLE
Bump pin to unify lint job versions across elements

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -1,0 +1,2 @@
+astroid==2.3.3
+pylint==2.4.4

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ skipsdist = True
 
 [testenv]
 usedevelop = true
-install_command = pip install -U {opts} {packages}
+install_command = pip install -c constraints.txt -U {opts} {packages}
 setenv =
   VIRTUAL_ENV={envdir}
   LANGUAGE=en_US


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

In an effort to unify the versions of pylint run across all the elements
this commit bumps the pinned versions of pylint and astroid to be the
latest and what we are syncing all the elements to use. This should make
working between all the elements easier to do. We should have been
pinning the pylint version anyway because each release of pylint and
astroid tends to introduce new failures.

### Details and comments

Related To: Qiskit/qiskit-terra#3629