### PR TITLE
update and check maximum number of shots

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Qiskit is an open-source framework for working with noisy intermediate-scale
 quantum computers (NISQ) at the level of pulses, circuits, and algorithms.
 
-This project contains a provider that allows access **[AQT]** ion-trap quantum
+This project contains a provider that allows access to **[AQT]** ion-trap quantum
 devices.
 
 ## Installation
@@ -37,12 +37,12 @@ Where `MY_TOKEN` is your access token for the AQT device. Then you can access
 the backends from that provider:
 
 ```python
-backends = aqt.backends()
-innsbruck_backend = aqt.get_backend('aqt_innsbruck')
+print(aqt.backends())
+backend = aqt.get_backend('aqt_qasm_simulator')
 ```
 
 You can then use that backend like you would use any other qiskit backend. For
-example, getting running a bell state:
+example, running a bell state:
 
 ```python
 from qiskit import *
@@ -50,10 +50,11 @@ qc = QuantumCircuit(2, 2)
 qc.h(0)
 qc.cx(0, 1)
 qc.measure([0,1], [0,1])
-result = execute(qc, innsbruck_backend).result()
+result = execute(qc, backend, shots=100).result()
 print(result.get_counts(qc))
 ```
 
+For running the quantum circuit on the ion-trap quantum device you need to use `aqt_innsbruck` as backend, which needs a different access token.
 
 ## Authors and Citation
 

--- a/qiskit/providers/aqt/aqt_backend.py
+++ b/qiskit/providers/aqt/aqt_backend.py
@@ -52,8 +52,8 @@ class AQTSimulator(BaseBackend):
 
     def run(self, qobj):
         if qobj.config.shots > self.configuration().max_shots:
-            raise ValueError('Number of shots is larger than maximum number of '
-                             'shots')
+            raise ValueError('Number of shots is larger than maximum '
+                             'number of shots')
         aqt_json = qobj_to_aqt.qobj_to_aqt(
             qobj, self._provider.access_token)[0]
         header = {
@@ -101,8 +101,8 @@ class AQTDevice(BaseBackend):
 
     def run(self, qobj):
         if qobj.config.shots > self.configuration().max_shots:
-            raise ValueError('Number of shots is larger than maximum number of '
-                             'shots')
+            raise ValueError('Number of shots is larger than maximum '
+                             'number of shots')
         aqt_json = qobj_to_aqt.qobj_to_aqt(
             qobj, self._provider.access_token)[0]
         header = {

--- a/qiskit/providers/aqt/aqt_backend.py
+++ b/qiskit/providers/aqt/aqt_backend.py
@@ -36,7 +36,7 @@ class AQTSimulator(BaseBackend):
             'memory': False,
             'n_qubits': 11,
             'conditional': False,
-            'max_shots': 250,
+            'max_shots': 200,
             'open_pulse': False,
             'gates': [
                 {
@@ -51,6 +51,9 @@ class AQTSimulator(BaseBackend):
             provider=provider)
 
     def run(self, qobj):
+        if qobj.config.shots > self.configuration().max_shots:
+            raise ValueError('Number of shots is larger than maximum number of '
+                             'shots')
         aqt_json = qobj_to_aqt.qobj_to_aqt(
             qobj, self._provider.access_token)[0]
         header = {
@@ -82,7 +85,7 @@ class AQTDevice(BaseBackend):
             'memory': False,
             'n_qubits': 4,
             'conditional': False,
-            'max_shots': 250,
+            'max_shots': 200,
             'open_pulse': False,
             'gates': [
                 {
@@ -97,6 +100,9 @@ class AQTDevice(BaseBackend):
             provider=provider)
 
     def run(self, qobj):
+        if qobj.config.shots > self.configuration().max_shots:
+            raise ValueError('Number of shots is larger than maximum number of '
+                             'shots')
         aqt_json = qobj_to_aqt.qobj_to_aqt(
             qobj, self._provider.access_token)[0]
         header = {


### PR DESCRIPTION
this PR updates the maximum number of shots for the two AQT backends and introduces a sanity check in the `run` methods of the backends.
The example in the readme is updated accordingly.