### PR TITLE
Add new simulator with noise model

### DIFF
--- a/qiskit/providers/aqt/aqt_provider.py
+++ b/qiskit/providers/aqt/aqt_provider.py
@@ -16,7 +16,7 @@
 from qiskit.providers.providerutils import filter_backends
 from qiskit.providers import BaseProvider
 
-from .aqt_backend import AQTSimulator, AQTDevice
+from .aqt_backend import AQTSimulator, AQTSimulatorNoise1, AQTDevice
 
 
 class AQTProvider(BaseProvider):
@@ -29,6 +29,7 @@ class AQTProvider(BaseProvider):
         self.name = 'aqt_provider'
         # Populate the list of AQT backends
         self._backends = [AQTSimulator(provider=self),
+                          AQTSimulatorNoise1(provider=self),
                           AQTDevice(provider=self)]
 
     def __str__(self):


### PR DESCRIPTION
A new simulator with a noise model is available in the AQT cloud. It is basically a copy of the already existing simulator without noise model. The new simulator backend name is defined as `aqt_qasm_simulator_noise_1` and it is available at the API URL `https://gateway.aqt.eu/marmot/sim/noise-model-1`.
