### PR TITLE
Update macOS image to use 10.15 instead of 10.13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -56,7 +56,7 @@ jobs:
           python.version: '3.8'
           TOXENV: py38
     pool:
-      vmImage: "macOS-10.13"
+      vmImage: "macOS-10.15"
     steps:
       - task: UsePythonVersion@0
         inputs:


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

The azure pipelines 10.13 agent is deprecated and will be removed by the
end of March 2019. To continue testing against macOS we need to switch
to a newer version of macOS. This commit updates the image used to the
latest version of macOS.

### Details and comments